### PR TITLE
fix: font loading

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -16,10 +16,10 @@ export async function initTypst(plugin: TypsidianPlugin) {
 			"https://cdn.jsdelivr.net/npm/@myriaddreamin/typst-ts-renderer/pkg/typst_ts_renderer_bg.wasm",
 	});
 
-	$typst.svg({ mainContent: "hello !" });
-
 	// add font
 	await fontInit(plugin.settings.supportLocalFonts);
+
+	$typst.svg({ mainContent: "hello !" });
 }
 
 export function regCmds(plugin: TypsidianPlugin) {


### PR DESCRIPTION
$typst.svg({ mainContent: "hello !" });
在调用之后无法使用下面这行代码正常加载字体:
await fontInit(plugin.settings.supportLocalFonts);
报错:

Plugin failure: fogsong-typsidian Error: already prepare uses for instances
    at TypstSnippet.use (plugin:fogsong-typsidian:55052:13)
    at fontInit (plugin:fogsong-typsidian:55583:12)
    at async initTypst (plugin:fogsong-typsidian:68388:3)
    at async TypsidianPlugin.onload (plugin:fogsong-typsidian:68432:5)

应该把两者调换顺序.