### PR TITLE
fix: inline math falls back to tex when typst2tex generates invalid tex code

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -115,7 +115,11 @@ export default class TypsidianPlugin extends Plugin {
 				if (source.includes("\\")) {
 					throw new Error(t("illegalTypstMathCode"));
 				}
-				return this.tex2html(typst2tex(source), r);
+				let renderedNode = this.tex2html(typst2tex(source), r);
+				if (renderedNode.querySelectorAll('[style*="color: red"]').length > 0) {
+					throw new Error(t("illegalTypstMathCode"));
+				}
+				return renderedNode;
 			}
 			return this.tex2html(source, r);
 		} catch (error) {


### PR DESCRIPTION
## Problem

The inline math symbol `$Bi$` fails to display correctly. This occurs because the `typst2tex` converter incorrectly translates `$Bi$` into the invalid tex command `\Bi`, which MathJax cannot render successfully.

## Solution

Implemented a safeguard where, upon detecting a rendering error within an inline math node, it triggers a fallback to display the original raw tex source. This prevents visual breakage caused by invalid intermediate code.